### PR TITLE
Support non-archive assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,16 @@ jobs:
           arch-linux: amd64
       - run: pandoc --version
 
+      - if: ${{ matrix.runner == 'ubuntu-latest' }}
+        uses: ./
+        with:
+          name: bluebook
+          version: 1.0.0.0
+          url: 'https://github.com/pbrisbin/{name}/releases/download/v{version}/{name}-{os}-{arch}'
+          no-extract: "true"
+      - if: ${{ matrix.runner == 'ubuntu-latest' }}
+        run: bluebook --help
+
       #
       # Random example from Freckle, that's a private repo. TODO: skip in
       # forks.

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,12 @@ inputs:
   ext:
     description: "{ext} to use instead of inferring"
 
+  no-extract:
+    description: |
+      Do not extract the asset as an archive. Rather, expect that it represents
+      the (only) binary itself. It will be downloaded, cached, and available on
+      $PATH as {name}.
+
   url-darwin:        { description: "url when platform==darwin" }
   url-linux:         { description: "url when platform==linux" }
   url-win32:         { description: "url when platform==win32" }

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -39,6 +39,7 @@ export interface Inputs {
   os: string;
   arch: string;
   ext: string;
+  noExtract: boolean;
   githubToken: string | null;
 }
 
@@ -67,6 +68,7 @@ export function getInputs(
       specifiedInputs(platform, osArch, "ext"),
       inferExtension(platform)
     ),
+    noExtract: core.getInput("no-extract", { required: false }) === "true",
     githubToken: core.getInput("github-token", { required: false }),
   };
 }


### PR DESCRIPTION
When a tool releases binaries attached directly to the Release, we can
now use `no-extract` to avoid treating them like archives. The asset
will be copied to `.../{name}` and made executable instead.